### PR TITLE
Lab 컨트랙트 작성 및 Study 컨트랙트 수정.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ client/package-lock.json
 client/src/contracts/Migrations.json
 client/src/contracts/SimpleStorage.json
 client/src/contracts/Study.json
+node_modules/*
+package.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # blockchainlab
 
-## 0. Dependency
-
-### Openzeppelin-solidity
-
-- To install openzeppelin-solidity library,
-> $ npm init -y
-
-> $ npm install --save-exact openzeppelin-solidity
-
 ## 1. Compile & Migrate contract
 
 - truffle develop

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # blockchainlab
 
+## 0. Dependency
+
+### Openzeppelin-solidity
+
+- To install openzeppelin-solidity library,
+> $ npm init -y
+> $ npm install --save-exact openzeppelin-solidity
+
 ## 1. Compile & Migrate contract
 
 - truffle develop

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - To install openzeppelin-solidity library,
 > $ npm init -y
+
 > $ npm install --save-exact openzeppelin-solidity
 
 ## 1. Compile & Migrate contract

--- a/contracts/Lab.sol
+++ b/contracts/Lab.sol
@@ -1,5 +1,8 @@
 pragma solidity ^0.5.0;
 
+/// @author The Modulabs Team
+/// @title A Study contract
+
 import "./Study.sol";
 
 contract Lab {
@@ -18,17 +21,20 @@ contract Lab {
         labName = _labName;
     }
 
+    function getStudyCount() public view returns(uint count) {
+        return studyList.length;
+    }
+
     function createStudy(
         string memory _studyName, 
         bytes32 _ownerName, 
         bytes32 _ownerEmail,
         bytes32 _syllabusURL) 
-        public returns (bool)
+        public
         {
-        Study newStudy = new Study(_studyName, _ownerName, _ownerEmail, _syllabusURL);
+        Study newStudy = new Study(msg.sender, _studyName, _ownerName, _ownerEmail, _syllabusURL);
         address _addr = address(newStudy);
         studyList.push(_addr);
         emit StudyCreated(_addr, msg.sender);
-        return true;
     }
 }

--- a/contracts/Lab.sol
+++ b/contracts/Lab.sol
@@ -18,11 +18,17 @@ contract Lab {
         labName = _labName;
     }
 
-    function createStudy(string memory _studyName) public {
-        Study newStudy = new Study();
-        newStudy.setStudyName(_studyName);
+    function createStudy(
+        string memory _studyName, 
+        bytes32 _ownerName, 
+        bytes32 _ownerEmail,
+        bytes32 _syllabusURL) 
+        public returns (bool)
+        {
+        Study newStudy = new Study(_studyName, _ownerName, _ownerEmail, _syllabusURL);
         address _addr = address(newStudy);
         studyList.push(_addr);
         emit StudyCreated(_addr, msg.sender);
+        return true;
     }
 }

--- a/contracts/Lab.sol
+++ b/contracts/Lab.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.5.0;
+
+import "./Study.sol";
+
+contract Lab {
+    address public _labOwner;
+    string public labName;
+    address[] public studyList;
+
+    event StudyCreated(address studyAddr, address studyAdmin);
+
+    constructor () public {
+        _labOwner = msg.sender;
+    }
+
+    function setLabName (string memory _labName) public {
+        require(msg.sender == _labOwner);
+        labName = _labName;
+    }
+
+    function createStudy(string memory _studyName) public {
+        Study newStudy = new Study();
+        newStudy.setStudyName(_studyName);
+        address _addr = address(newStudy);
+        studyList.push(_addr);
+        emit StudyCreated(_addr, msg.sender);
+    }
+}

--- a/contracts/Study.sol
+++ b/contracts/Study.sol
@@ -1,108 +1,244 @@
 pragma solidity ^0.5.0;
 
+/// @author The Modulabs Team
+/// @title A Study contract
+
 contract Study {
 
     struct Student {
         bytes32 name;
         bytes32 email;
+        bool isStudent;
         bool isAdmin;
     }
 
     struct Session {
         bytes32 sessionName;
         bytes32 materialURL;
-        address[] attandeeList;
+        address[] attendeeList;
     }
+
+    enum MemberState { StudentAssigned, StudentRemoved, AdminAssigned, AdminRemoved }
 
     address payable studyOwner;
     string studyName;
     bytes32 syllabusURL;
     
-    mapping(address => Student) public students;
-    mapping(uint => Session) public sessions;
+    mapping(address => Student) students;
+    mapping(uint => Session) sessions;
+    uint studentNumber;
     uint sessionNumber;
 
-    // modifier for admin
+    /// modifier for admin
     modifier onlyAdmin() {
         require(students[msg.sender].isAdmin, "Only study admin can call this function!");
         _;
     }
-    // modifier for owner
+
+    /// modifier for owner
     modifier onlyOwner() {
         require(msg.sender == studyOwner, "Only study owner can call this function!");
         _;
     }
 
-    // events
+    /// events
     event StudyStateChange(string _studyName, bytes32 _syllabusURL, string message);
-    event MemberStateChange(address member,string message);
+    /**
+     * @dev event MemberStateChange
+     * @notice parameter memberState = {0: StudentAssigned, 1: StudentRemoved, 2: AdminAssigned, 3:AdminRemoved}
+     */
+    event MemberStateChange(address indexed member, int8 indexed memberState);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    constructor(string memory _studyName, bytes32 _ownerName, bytes32 _ownerEmail, bytes32 _syllabusURL) public {
+    /**
+     * @dev Constructor of Study Contract, sets basic information of the _studyOwner in Student struct.
+     * @param _studyOwner Who called createStudy method in Lab contract
+     * @param _studyName Name of the study
+     * @param _ownerName ,@param _ownerEmail : Owner Info
+     * @param _syllabusURL URL to the documentation that describes this study
+     * @notice sessionNumber is initialized to 1. the zeroth session might be special session (e.g. Orientation)
+     * that can be set by study owner.
+     * @notice Study owner is the study owner by default.
+     */
+    constructor(address payable _studyOwner, string memory _studyName, bytes32 _ownerName, bytes32 _ownerEmail, bytes32 _syllabusURL) public {
         studyName = _studyName;
-        studyOwner = msg.sender;
-        students[studyOwner] = Student(_ownerName, _ownerEmail, true);
+        studyOwner = _studyOwner;
+        students[studyOwner] = Student(_ownerName, _ownerEmail, true, true);
         syllabusURL = _syllabusURL;
         sessionNumber = 1;
+        studentNumber = 1;
         emit StudyStateChange(_studyName, _syllabusURL, "Study Created");
     }
 
-    // Functions for set or get member state of Study
-    function setStudent(bytes32 _name, bytes32 _email, address _candidate) public onlyAdmin{
-        students[_candidate] = Student(_name, _email, false);
-        emit MemberStateChange(_candidate, "New student added.");
+    /**
+     * @dev Simple Functions for extracting study information. 
+     */
+    function getStudyName() public view returns (string memory) {
+        return studyName;
     }
 
-    function getStudentInfo(address _student) public view returns (bytes32, bytes32) {
-        require(msg.sender == _student || students[msg.sender].isAdmin);
-        return (students[_student].name, students[_student].email);
-    }
-
-    function setAdmin(address _candidate) public onlyOwner{
-        // require(students[_candidate] != 0, "This address is not student.");
-        students[_candidate].isAdmin = true;
-        emit MemberStateChange(_candidate, "New admin assigned.");
+    function getSyllabus() public view returns (bytes32) {
+        return syllabusURL;
     }
 
     function getOwner() public view returns(address) {
         return studyOwner;
     }
 
-    // Functions for sessions in study
-    function AddSession(bytes32 _sessionName, bytes32 _materialURL) public onlyAdmin{
+    /**
+     * @dev Function for set student by adding Student struct to the students mapping.
+     * only admin can set the student.
+     * event emitted by the student addition.
+     */
+    function setStudent(bytes32 _name, bytes32 _email, address _candidate) public onlyAdmin{
+        students[_candidate] = Student(_name, _email, true, false);
+        emit MemberStateChange(_candidate, int8(MemberState.StudentAssigned));
+        studentNumber++;
+    }
+
+    /**
+     * @dev Function for remove student by changing Student struct in the students mapping.
+     * only admin can remove the student.
+     * event emitted by the student addition.
+     */
+    function removeStudent(address _student) public onlyAdmin{
+        require(students[_student].isStudent == true, "This address is not a student");
+        require(students[_student].isAdmin == false, "Admin member can not be removed by other admin");
+        students[_student] = Student(0, 0, false, false);
+        emit MemberStateChange(_student, int8(MemberState.StudentRemoved));
+        studentNumber--;
+    }
+
+    /**
+     * @dev Function for extracting student's basic information.
+     * only the student itself and admin can get the info.
+     * @return student name and email in bytes32 type.
+     */
+    function getStudentInfo(address _student) public view returns (bytes32, bytes32, bool) {
+        require(msg.sender == _student || students[msg.sender].isAdmin);
+        return (students[_student].name, students[_student].email, students[_student].isAdmin);
+    }
+
+    /**
+     * @dev Function for setting admin. This is can only be run by the studyOwner.
+     * @notice There might be more than one admins.
+     * @param _candidate is the admin candidate address which is required to be a student in advance.
+     */
+    function setAdmin(address _candidate) public onlyOwner{
+        require(students[_candidate].isStudent, "This address is not student.");
+        require(students[_candidate].isAdmin == false, "This address is already an admin.");
+        students[_candidate].isAdmin = true;
+        emit MemberStateChange(_candidate, int8(MemberState.AdminAssigned));
+    }
+
+    /**
+     * @dev Function for removing admin. This is can only be run by the studyOwner.
+     * @param _admin is the admin candidate address which is required to be an admin in advance.
+     */
+    function removeAdmin(address _admin) public onlyOwner{
+        require(students[_admin].isStudent == true, "This address is not a student");
+        require(students[_admin].isAdmin == true, "This address is not an admin.");
+        students[_admin].isAdmin = false;
+        emit MemberStateChange(_admin, int8(MemberState.AdminRemoved));
+    }
+    
+
+    /**
+     * @dev Function for add one session to the sessions mapping, only Admin can set it.
+     * @param _sessionName : bytes32 type session name.
+     * @param _materialURL : bytes32 type URL of session material.
+     */
+    function addSession(bytes32 _sessionName, bytes32 _materialURL) public onlyAdmin{
         Session memory newSession = Session({
             sessionName: _sessionName,
             materialURL: _materialURL,
-            attandeeList: new address[](0)
-        }); // Have to check that newsession is not disappeared after func. AddSession is ended.
+            attendeeList: new address[](0)
+        }); 
         sessions[sessionNumber] = newSession;
         sessionNumber++;
     }
 
-    // function getSessionInfo(uint _sessionNumber) public view returns (Session memory) {
-    //     // require(sessions[_sessionNumber] != 0, "This session is not set yet.");
-    //     return sessions[_sessionNumber];
-    //   }
+    /**
+     * @dev Function get basic session information.
+     * @param _sessionNumber : the number of session we want to get information from.
+     * @return basic session information(session Name, Session material URL) in bytes32 type.
+     */
+    function getSessionInfo(uint _sessionNumber) public view returns (bytes32, bytes32) {
+        require(sessions[_sessionNumber].sessionName != 0, "This session is not set yet.");
+        return (sessions[_sessionNumber].sessionName, sessions[_sessionNumber].materialURL);
+    }
 
-    // function setAttendance(uint _sessionNumber, address _attendee) public onlyAdmin {
-    //     // require(sessions[_sessionNumber] != 0, "This session is not set yet.");
-    //     sessions[_sessionNumber].attendeeList.push(_attendee);
-    // }
+    /**
+     * @dev Function for set attendance in the specific session.
+     * @param _sessionNumber : the session we want to add attendance.
+     * @param _attendee : the address who attended the session.
+     * @notice Only admin can call this function and the attendee is required to be a student.
+     * @notice new attendee added to the attendeeList in the Session.attendeeList.
+     */
+    function setAttendance(uint _sessionNumber, address _attendee) public onlyAdmin {
+        require(sessions[_sessionNumber].sessionName != 0, "This session is not set yet.");
+        require(students[_attendee].isStudent, "This address is not student.");
+        sessions[_sessionNumber].attendeeList.push(_attendee);
+    }
 
-    // function getAttendance(uint _sessionNumber) public view returns (address[] memory attendeeList) {
-    //     // require(sessions[_sessionNumber] != 0, "This session is not set yet.");
-    //     return sessions[_sessionNumber].attendeeList;    
-    //   }
+    /**
+     * @dev Function for get attendance of specific session.
+     * @param _sessionNumber specific session number that we want to know.
+     * @return attendeeList of the session
+     */
+    function getAttendance(uint _sessionNumber) public view returns (address[] memory attendeeList) {
+        require(sessions[_sessionNumber].sessionName != 0, "This session is not set yet.");
+        return sessions[_sessionNumber].attendeeList;    
+    }
 
-    // Functions for changing study states
+    /**
+     * @dev Function for changing studyName.
+     * @param _studyName : new study name in string type.
+     * @notice only Owner of the study can change the study name.
+     * @notice event StudyStateChange emitted.
+     */
     function changeStudyName(string memory _studyName) public onlyOwner{
         studyName = _studyName;
         emit StudyStateChange(_studyName, syllabusURL, "Study name changed");
     }
 
+    /**
+     * @dev Function for changing study syllabusURL.
+     * @param _syllabusURL : new study syllabusURL in bytes32 type.
+     * @notice only Owner of the study can change the study syllabusURL.
+     * @notice event StudyStateChange emitted.
+     */
     function changeSyllabusURL(bytes32 _syllabusURL) public onlyOwner{
         syllabusURL = _syllabusURL;
         emit StudyStateChange(studyName, _syllabusURL, "Syllabus URL changed");
     }
+
+    /**
+     * @dev Functions for ownership management.
+     * @param newOwner The address to transfer ownership to.
+     * @notice only Owner can call this function
+     */
+    function transferOwnership(address payable newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+
+    /**
+     * @dev Helper functions for ownership management.
+     * @param newOwner The address to transfer ownership to.
+     * @notice check if the newOwner is the zero address, so that the ownership can be recovered.
+     * @notice only Owner can call this function
+     */
+    function _transferOwnership(address payable newOwner) internal {
+        require(newOwner != address(0));
+        emit OwnershipTransferred(studyOwner, newOwner);
+        studyOwner = newOwner;
+    }
+
+    /**
+     * @dev Study destruction function
+     * @notice only Owner can call this function
+     */    
     function kill() public onlyOwner{
         selfdestruct(msg.sender);
     }

--- a/contracts/Study.sol
+++ b/contracts/Study.sol
@@ -5,66 +5,109 @@ contract Study {
     struct Student {
         bytes32 name;
         bytes32 email;
+        bool isAdmin;
     }
 
-    struct Lecture {
-        bytes32 lectureName;
-        address[] attandee;
+    struct Session {
+        bytes32 sessionName;
+        bytes32 materialURL;
+        address[] attandeeList;
     }
 
-    address studyAdmin;
+    address payable studyOwner;
     string studyName;
+    bytes32 syllabusURL;
+    
     mapping(address => Student) public students;
-    Lecture[] class;
+    mapping(uint => Session) public sessions;
+    uint sessionNumber;
 
-    constructor() public {
-        studyAdmin = msg.sender;
-
+    // modifier for admin
+    modifier onlyAdmin() {
+        require(students[msg.sender].isAdmin, "Only study admin can call this function!");
+        _;
+    }
+    // modifier for owner
+    modifier onlyOwner() {
+        require(msg.sender == studyOwner, "Only study owner can call this function!");
+        _;
     }
 
-    function setLecture(bytes32[] memory lectureNames) public {
-        require(msg.sender == studyAdmin);
-        for(uint i=0; i<lectureNames.length; i++) {
-            class.push(Lecture({
-                lectureName: lectureNames[i],
-                attandee: new address[](0)
-            }));
-        }
-    }
+    // events
+    event StudyStateChange(string _studyName, bytes32 _syllabusURL, string message);
+    event MemberStateChange(address member,string message);
 
-    function setStudyName(string memory _studyName) public {
+    constructor(string memory _studyName, bytes32 _ownerName, bytes32 _ownerEmail, bytes32 _syllabusURL) public {
         studyName = _studyName;
+        studyOwner = msg.sender;
+        students[studyOwner] = Student(_ownerName, _ownerEmail, true);
+        syllabusURL = _syllabusURL;
+        sessionNumber = 1;
+        emit StudyStateChange(_studyName, _syllabusURL, "Study Created");
     }
 
-    function kill() public{
-        require(msg.sender == studyAdmin);
+    // Functions for set or get member state of Study
+    function setStudent(bytes32 _name, bytes32 _email, address _candidate) public onlyAdmin{
+        students[_candidate] = Student(_name, _email, false);
+        emit MemberStateChange(_candidate, "New student added.");
+    }
+
+    function getStudentInfo(address _student) public view returns (bytes32, bytes32) {
+        require(msg.sender == _student || students[msg.sender].isAdmin);
+        return (students[_student].name, students[_student].email);
+    }
+
+    function setAdmin(address _candidate) public onlyOwner{
+        // require(students[_candidate] != 0, "This address is not student.");
+        students[_candidate].isAdmin = true;
+        emit MemberStateChange(_candidate, "New admin assigned.");
+    }
+
+    function getOwner() public view returns(address) {
+        return studyOwner;
+    }
+
+    // Functions for sessions in study
+    function AddSession(bytes32 _sessionName, bytes32 _materialURL) public onlyAdmin{
+        Session memory newSession = Session({
+            sessionName: _sessionName,
+            materialURL: _materialURL,
+            attandeeList: new address[](0)
+        }); // Have to check that newsession is not disappeared after func. AddSession is ended.
+        sessions[sessionNumber] = newSession;
+        sessionNumber++;
+    }
+
+    // function getSessionInfo(uint _sessionNumber) public view returns (Session memory) {
+    //     // require(sessions[_sessionNumber] != 0, "This session is not set yet.");
+    //     return sessions[_sessionNumber];
+    //   }
+
+    // function setAttendance(uint _sessionNumber, address _attendee) public onlyAdmin {
+    //     // require(sessions[_sessionNumber] != 0, "This session is not set yet.");
+    //     sessions[_sessionNumber].attendeeList.push(_attendee);
+    // }
+
+    // function getAttendance(uint _sessionNumber) public view returns (address[] memory attendeeList) {
+    //     // require(sessions[_sessionNumber] != 0, "This session is not set yet.");
+    //     return sessions[_sessionNumber].attendeeList;    
+    //   }
+
+    // Functions for changing study states
+    function changeStudyName(string memory _studyName) public onlyOwner{
+        studyName = _studyName;
+        emit StudyStateChange(_studyName, syllabusURL, "Study name changed");
+    }
+
+    function changeSyllabusURL(bytes32 _syllabusURL) public onlyOwner{
+        syllabusURL = _syllabusURL;
+        emit StudyStateChange(studyName, _syllabusURL, "Syllabus URL changed");
+    }
+    function kill() public onlyOwner{
         selfdestruct(msg.sender);
     }
 
-    function getAdmin() public view returns(address) {
-        return studyAdmin;
-    }
+    
 
-    function setStudent(bytes32 name, bytes32 email) public{
-        students[msg.sender] = Student(name, email);
-    }
-
-    function getStudent(address st) public view returns(bytes32, bytes32) {
-        require(msg.sender == st || msg.sender == studyAdmin);
-        return (students[st].name, students[st].email);
-    }
-
-    function getLectures() public view returns (bytes32[] memory lectureList) {
-        lectureList = new bytes32[](class.length);
-        for(uint i=0; i<class.length; i++) {
-            lectureList[i] = class[i].lectureName;
-        }
-    }
-    function setAttendance(uint lectureNum) public {
-        class[lectureNum].attandee.push(msg.sender);
-    }
-
-    function getAttendance(uint lectureNum) public view returns (address[] memory){
-        return class[lectureNum].attandee;
-    }
-}
+    
+}   

--- a/contracts/Study.sol
+++ b/contracts/Study.sol
@@ -1,30 +1,5 @@
 pragma solidity ^0.5.0;
 
-contract Lab {
-    address public _labOwner;
-    string public labName;
-    address[] public studyList;
-
-    event StudyCreated(address studyAddr, address studyAdmin);
-
-    constructor () public {
-        _labOwner = msg.sender;
-    }
-
-    function setLabName (string memory _labName) public {
-        require(msg.sender == _labOwner);
-        labName = _labName;
-    }
-
-    function createStudy(string memory _studyName) public {
-        Study newStudy = new Study();
-        newStudy.setStudyName(_studyName);
-        address _addr = address(newStudy);
-        studyList.push(_addr);
-        emit StudyCreated(_addr, msg.sender);
-    }
-}
-
 contract Study {
 
     struct Student {

--- a/contracts/Study.sol
+++ b/contracts/Study.sol
@@ -1,33 +1,95 @@
 pragma solidity ^0.5.0;
 
+contract Lab {
+    address public _labOwner;
+    string public labName;
+    address[] public studyList;
+
+    event StudyCreated(address studyAddr, address studyAdmin);
+
+    constructor () public {
+        _labOwner = msg.sender;
+    }
+
+    function setLabName (string memory _labName) public {
+        require(msg.sender == _labOwner);
+        labName = _labName;
+    }
+
+    function createStudy(string memory _studyName) public {
+        Study newStudy = new Study();
+        newStudy.setStudyName(_studyName);
+        address _addr = address(newStudy);
+        studyList.push(_addr);
+        emit StudyCreated(_addr, msg.sender);
+    }
+}
+
 contract Study {
-  string labAdmin;
-  uint numOfStudent = 2; // hardcoded for now
-  bytes8[] memberList = new bytes8[](numOfStudent); // init list
-  uint numOfSylabus = 5;
-  bytes4[] syllabusList = new bytes4[](numOfSylabus);
 
-  function setAdmin(string memory s) public {
-    labAdmin = s;
-  }
+    struct Student {
+        bytes32 name;
+        bytes32 email;
+    }
 
-  function getAdmin() public view returns(string memory) {
-    return labAdmin;
-  }
+    struct Lecture {
+        bytes32 lectureName;
+        address[] attandee;
+    }
 
-  function setMember(bytes8 member) public {
-    memberList.push(member);
-  }
+    address studyAdmin;
+    string studyName;
+    mapping(address => Student) public students;
+    Lecture[] class;
 
-  function getMembers() public returns(bytes8[] memory) {
-    return memberList;
-  }
+    constructor() public {
+        studyAdmin = msg.sender;
 
-  function setSyllabus(bytes4 sylabus) public {
-    syllabusList.push(sylabus);
-  }
+    }
 
-  function getSyllabus() public returns(bytes4[] memory) {
-    return syllabusList;
-  }
+    function setLecture(bytes32[] memory lectureNames) public {
+        require(msg.sender == studyAdmin);
+        for(uint i=0; i<lectureNames.length; i++) {
+            class.push(Lecture({
+                lectureName: lectureNames[i],
+                attandee: new address[](0)
+            }));
+        }
+    }
+
+    function setStudyName(string memory _studyName) public {
+        studyName = _studyName;
+    }
+
+    function kill() public{
+        require(msg.sender == studyAdmin);
+        selfdestruct(msg.sender);
+    }
+
+    function getAdmin() public view returns(address) {
+        return studyAdmin;
+    }
+
+    function setStudent(bytes32 name, bytes32 email) public{
+        students[msg.sender] = Student(name, email);
+    }
+
+    function getStudent(address st) public view returns(bytes32, bytes32) {
+        require(msg.sender == st || msg.sender == studyAdmin);
+        return (students[st].name, students[st].email);
+    }
+
+    function getLectures() public view returns (bytes32[] memory lectureList) {
+        lectureList = new bytes32[](class.length);
+        for(uint i=0; i<class.length; i++) {
+            lectureList[i] = class[i].lectureName;
+        }
+    }
+    function setAttendance(uint lectureNum) public {
+        class[lectureNum].attandee.push(msg.sender);
+    }
+
+    function getAttendance(uint lectureNum) public view returns (address[] memory){
+        return class[lectureNum].attandee;
+    }
 }


### PR DESCRIPTION
# 1. Lab 컨트랙트 작성
Study contract를 생성하고, 생성된 주소를 저장하는 단순한 Lab 컨트랙트를 작성했습니다.

#2 Study 컨트랙트 수정 및 작성
- @currybab 님께서 저번에 커밋하신 내용을 바탕으로 Lab 컨트랙트와 맞게 레벨을 조정했습니다.
- Lab > Study > Session (lecture 이름을 변경) 순으로 구조를 잡았습니다.
- Study 컨트랙트 내의 권한은, 세 단계로 나누었습니다. 1. StudyOwner 2. StudyAdmin, 3.Student.
- 1,2,3 권한 레벨 모두는 Student이고, StudyOwner는 컨트랙트의 생성자이자 Admin을 임명 가능한 사람입니다.
- Admin은 Student 중 Owner가 임명하고, 한 컨트랙트 내 여러명이 될 수 있습니다.
- Student Struct 안에 기본적인 정보 (이름, 이메일)과, 권한 정보가 들어갑니다.
- Session Struct 안에 각 세션에 대한 정보(이름, Material URL)와, 참여자 리스트가 `address[]`로 들어갑니다.
- `enum MemberState`는 스터디 컨트랙트 내 멤버 상태 변동에 대한 이벤트 생성에 쓰입니다.
- Ownerble 기능 추가 : studyOwner 권한을 다른 주소로 넘겨주는 기능 추가. 

#4. .gitignore 수정

